### PR TITLE
demo shows indented body text of bullet item

### DIFF
--- a/FTCoreText/articleViewController.m
+++ b/FTCoreText/articleViewController.m
@@ -64,6 +64,7 @@
 	bulletStyle.bulletFont = [UIFont fontWithName:@"TimesNewRomanPSMT" size:16.f];
 	bulletStyle.bulletColor = [UIColor orangeColor];
 	bulletStyle.bulletCharacter = @"❧";
+	bulletStyle.paragraphInset = UIEdgeInsetsMake(0, 20.f, 0, 0);
 	[result addObject:bulletStyle];
     
     FTCoreTextStyle *italicStyle = [defaultStyle copy];

--- a/FTCoreText/text.txt
+++ b/FTCoreText/text.txt
@@ -1,10 +1,10 @@
 <title>Giraffe</title>
 <_image>giraffe.png</_image>
-<firstLetter>T</firstLetter>he giraffe (Giraffa camelopardalis) is an African <_link>http://en.wikipedia.org/wiki/Even-toed_ungulate|even-toed ungulate</_link> mammal, the tallest of all extant land-living animal species, and the largest ruminant. Its ssdfsdfdsfsdcientific name,<_link>http://en.wikipedia.org/wiki/Giraffe|©2011 - Wikipedia</_link> which is similar to its archaic English name of camelopard, refers to its irregular patches of color on a light background.
+<firstLetter>T</firstLetter>he giraffe (Giraffa camelopardalis) is an African <_link>http://en.wikipedia.org/wiki/Even-toed_ungulate|even-toed ungulate</_link> mammal, the tallest of all extant land-living animal species, and the largest ruminant. Its scientific name,<_link>http://en.wikipedia.org/wiki/Giraffe|©2011 - Wikipedia</_link> which is similar to its archaic English name of camelopard, refers to its irregular patches of color on a light background.
 <subtitle>Subspecies</subtitle>
 Different authorities recognize different numbers of subspecies,<_link>http://en.wikipedia.org/wiki/Giraffe|©2011 - Wikipedia</_link> differentiated by <bold>size</bold>, <colored>color</colored> and <italic>pattern</italic> variations and range. Some of these subspecies may prove to be separate species as they appear to be reproductively isolated despite their mobility. The subspecies recognized by most recent authorities are:
 
-<_bullet>G. c. camelopardalis</_bullet>
+<_bullet>G. c. camelopardalis, an unusual specimen which can only be well-described a long line of text we hope will wrap correctly when presented as an item in a bullet list.</_bullet>
 <_bullet>G. c. reticulata</_bullet>
 <_bullet>G. c. reticulata</_bullet>
 <_bullet>G. c. angolensis</_bullet>


### PR DESCRIPTION
This updates the demo app to show how to set the indentation for the text following a bullet item, i.e., to produce a "hanging indent".

I think this is worth illustrating because this is the layout people usually want for bullet items, and because, I believe, it is impossible to do on iOS5 and iOS6 without using CoreText.
