### PR TITLE
Fix detecting touches on links for devices with force touch support

### DIFF
--- a/FTCoreText/FTCoreTextView.m
+++ b/FTCoreText/FTCoreTextView.m
@@ -1362,6 +1362,12 @@ CTFontRef CTFontCreateFromUIFont(UIFont *font)
 
 - (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event
 {
+    UITouch *touch = [touches anyObject];
+    CGPoint currentTouchPosition = [touch locationInView:touch.window];
+    CGPoint oldTouchPosition = [touch previousLocationInView:touch.window];
+    if (CGPointEqualToPoint(currentTouchPosition, oldTouchPosition)) {
+        return;
+    }
 	_touchedData = nil;
 	[_selectionsViews makeObjectsPerformSelector:@selector(removeFromSuperview)];
 	_selectionsViews = nil;


### PR DESCRIPTION
On devices with force touch increasing the pressure leads to touchesMoved callback
which invalidated touch data required in touchesEnded to inform a delegate.
After this change coordinates are taken into account to detect if movement has really
occured.